### PR TITLE
Fill missing Open Graph metadata

### DIFF
--- a/src/app/[locale]/blog/layout.tsx
+++ b/src/app/[locale]/blog/layout.tsx
@@ -12,8 +12,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/blog",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Blog",
       },
     ],
   },
@@ -23,8 +23,8 @@ export const metadata: Metadata = {
       "Stay updated with the latest insights about AI technology and implementation. Explore our blog for articles, tips, and trends.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Blog",
       },
     ],
   },

--- a/src/app/[locale]/cookie-policy/page.tsx
+++ b/src/app/[locale]/cookie-policy/page.tsx
@@ -28,8 +28,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/cookie-policy",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Cookie Policy",
       },
     ],
   },
@@ -39,8 +39,8 @@ export const metadata: Metadata = {
       "Everything you need to know about cookies and tracking technologies used on NeuroGen Lab website.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Cookie Policy",
       },
     ],
   },

--- a/src/app/[locale]/disclaimer/page.tsx
+++ b/src/app/[locale]/disclaimer/page.tsx
@@ -26,8 +26,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/disclaimer",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Legal Disclaimer",
       },
     ],
   },
@@ -37,8 +37,8 @@ export const metadata: Metadata = {
       "Essential legal information about using NeuroGen Lab's website and services. Read our full disclaimer and terms of use.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Legal Disclaimer",
       },
     ],
   },

--- a/src/app/[locale]/impressum/page.tsx
+++ b/src/app/[locale]/impressum/page.tsx
@@ -27,8 +27,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/impressum",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Legal Notice",
       },
     ],
   },
@@ -38,8 +38,8 @@ export const metadata: Metadata = {
       "Official company information and legal details for NeuroGen Lab GmbH. Registration number, VAT ID, and contact information.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Legal Notice",
       },
     ],
   },

--- a/src/app/[locale]/privacy/page.tsx
+++ b/src/app/[locale]/privacy/page.tsx
@@ -29,8 +29,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/privacy",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Privacy Policy",
       },
     ],
   },
@@ -40,8 +40,8 @@ export const metadata: Metadata = {
       "Discover how we protect your privacy and handle your personal information. Complete overview of our data protection practices and your rights.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Privacy Policy",
       },
     ],
   },

--- a/src/app/[locale]/responsible-ai-policy/page.tsx
+++ b/src/app/[locale]/responsible-ai-policy/page.tsx
@@ -30,8 +30,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/responsible-ai-policy",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Responsible AI Policy",
       },
     ],
   },
@@ -41,8 +41,8 @@ export const metadata: Metadata = {
       "Our commitment to ethical AI development and implementation. Comprehensive guidelines ensuring responsible AI usage and user protection.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Responsible AI Policy",
       },
     ],
   },

--- a/src/app/[locale]/terms/page.tsx
+++ b/src/app/[locale]/terms/page.tsx
@@ -58,8 +58,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/terms",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Terms of Service",
       },
     ],
   },
@@ -69,8 +69,8 @@ export const metadata: Metadata = {
       "Essential information about your rights and obligations when using NeuroGen Lab's AI services. Read our complete terms of service.",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-guide.jpg",
+        alt: "NeuroGen Lab Terms of Service",
       },
     ],
   },

--- a/src/app/[locale]/tools/ai-assistant/metadata.ts
+++ b/src/app/[locale]/tools/ai-assistant/metadata.ts
@@ -17,8 +17,8 @@ export const metadata: Metadata = {
     url: "https://neurogenlab.de/tools/ai-assistant",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-ai-assistant.jpg",
+        alt: "NeuroGen Lab AI Assistant",
       },
     ],
   },
@@ -27,8 +27,8 @@ export const metadata: Metadata = {
     description: "Enhance your business efficiency with our AI Assistant",
     images: [
       {
-        url: "", // TODO: add url and alt
-        alt: "",
+        url: "/assets/images/og-ai-assistant.jpg",
+        alt: "NeuroGen Lab AI Assistant",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- add alt text and image paths for open graph metadata

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684007b10114832888a37a063461e540