### PR TITLE
Fix db connect log typo

### DIFF
--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -33,7 +33,7 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     await dbConnect();
-    console.log("db connect succesful!");
+    console.log("db connect successful!");
 
     const form = await req.formData();
     const images = form.getAll("images") as File[];
@@ -83,7 +83,7 @@ export async function POST(req: NextRequest) {
 export async function PUT(req: Request) {
   try {
     await dbConnect();
-    console.log("db connect succesful!");
+    console.log("db connect successful!");
 
     const form = await req.formData();
     const images = form.getAll("images") as File[];


### PR DESCRIPTION
## Summary
- correct spelling in API blog route

## Testing
- `npm run lint` *(fails: Invalid option '--ext' due to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6840250feae08328908c0d0548f1fc7d